### PR TITLE
Support for TLS certificate authentication

### DIFF
--- a/lib/logstash/plugin_mixins/rabbitmq_connection.rb
+++ b/lib/logstash/plugin_mixins/rabbitmq_connection.rb
@@ -57,6 +57,12 @@ module LogStash
         # Passive queue creation? Useful for checking queue existance without modifying server state
         config :passive, :validate => :boolean, :default => false
 
+        # TLS certifcate path
+        config :tls_certificate_path, :validate => :string, :default => ""
+
+        # TLS certificate password
+        config :tls_certificate_password, :validate => :string, :default => ""
+        
         # Extra queue arguments as an array.
         # To make a RabbitMQ queue mirrored, use: `{"x-ha-policy" => "all"}`
         config :arguments, :validate => :array, :default => {}
@@ -87,6 +93,8 @@ module LogStash
         s[:timeout] = @connection_timeout || 0
         s[:heartbeat] = @heartbeat || 0
         s[:tls] = @ssl if @ssl
+        s[:tls_certificate_path] = @tls_certificate_path || ""
+        s[:tls_certificate_password] = @tls_certificate_password || ""
         @rabbitmq_settings = s
       end
 

--- a/lib/logstash/plugin_mixins/rabbitmq_connection.rb
+++ b/lib/logstash/plugin_mixins/rabbitmq_connection.rb
@@ -34,7 +34,8 @@ module LogStash
         config :vhost, :validate => :string, :default => "/"
 
         # Enable or disable SSL
-        config :ssl, :validate => :boolean, :default => false
+        # Specify TLS version if using TLS e.g "TLSv1.2"
+        config :ssl, :validate => :string, :default => false
 
         # Validate SSL certificate
         config :verify_ssl, :validate => :boolean, :default => false


### PR DESCRIPTION
Adding "tls_certificate_path" & "tls_certificate_password" as input options for logstash plugin.
I will do the corresponding change to "logstash-mixin-rabbitmq_connection" & "march_hare" code as well.
