### PR TITLE
Bump to latest rabbitmq version

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,5 @@
+* 2.3.0
+  - Bump march_mare version to 2.15.0 to fix perms issue internal to march hare gem (.jar not installed with o+r perms)
 * 2.2.0
   - Rollback the changes in 2.1.0 . prefetch_count only belongs in the input plugin
 * 2.1.0

--- a/logstash-mixin-rabbitmq_connection.gemspec
+++ b/logstash-mixin-rabbitmq_connection.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency "logstash-core", ">= 2.0.0.beta2", "< 3.0.0"
 
   s.platform = RUBY_PLATFORM
-  s.add_runtime_dependency 'march_hare', ['~> 2.11.0'] #(MIT license)
+  s.add_runtime_dependency 'march_hare', ['~> 2.15.0'] #(MIT license)
   s.add_runtime_dependency 'stud', '~> 0.0.22'
 
   s.add_development_dependency 'logstash-devutils'


### PR DESCRIPTION
This should fix https://github.com/logstash-plugins/logstash-output-rabbitmq/issues/30#event-443676459 which used a broken version of march_hare. I have confirmed that this version uses the correct perms.
