### PR TITLE
Docs: Clarify that vhost names don't begin with a slash

### DIFF
--- a/lib/logstash/plugin_mixins/rabbitmq_connection.rb
+++ b/lib/logstash/plugin_mixins/rabbitmq_connection.rb
@@ -30,7 +30,10 @@ module LogStash
         # RabbitMQ password
         config :password, :validate => :password, :default => "guest"
 
-        # The vhost to use. If you don't know what this is, leave the default.
+        # The vhost (virtual host) to use. If you don't know what this
+        # is, leave the default. With the exception of the default
+        # vhost ("/"), names of vhosts should not begin with a forward
+        # slash.
         config :vhost, :validate => :string, :default => "/"
 
         # Enable or disable SSL


### PR DESCRIPTION
With the exception of the default "/" vhost, vhost names don't begin with a slash and we can help users by being more explicit about this. Fixes https://github.com/logstash-plugins/logstash-input-rabbitmq/issues/25.
