### PR TITLE
Add support for extra exchanges

### DIFF
--- a/lib/logstash/plugin_mixins/rabbitmq_connection.rb
+++ b/lib/logstash/plugin_mixins/rabbitmq_connection.rb
@@ -8,7 +8,7 @@ require "java"
 module LogStash
   module PluginMixins
     module RabbitMQConnection
-      EXCHANGE_TYPES = ["fanout", "direct", "topic"]
+      EXCHANGE_TYPES = ["fanout", "direct", "topic", "x-consistent-hash", "x-modulus-hash"]
 
       HareInfo = Struct.new(:connection, :channel, :exchange, :queue)
 


### PR DESCRIPTION
This pull requests adds support for using the RabbitMQ plugin to connect to exchanges using the consistent hash exchange (https://github.com/rabbitmq/rabbitmq-consistent-hash-exchange) or the sharded queues exchange (https://github.com/rabbitmq/rabbitmq-sharding)

This closes #11
