### PR TITLE
bumped version to 2.4.1 and fixed backwards incompatible behaviour

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,5 @@
+* 2.4.1
+  - Fixed backward incompatible SSL Support
 * 2.4.0
   - Add SSL/TLS Support
   - Add support for "x-consistent-hash" and "x-modulus-hash" exchanges

--- a/lib/logstash/plugin_mixins/rabbitmq_connection.rb
+++ b/lib/logstash/plugin_mixins/rabbitmq_connection.rb
@@ -96,7 +96,11 @@ module LogStash
 
         s[:timeout] = @connection_timeout || 0
         s[:heartbeat] = @heartbeat || 0
-        s[:tls] = @ssl if @ssl
+        if @ssl && @ssl == 'true'
+          s[:tls] = true
+        else
+          s[:tls] = @ssl if @ssl
+        end
         s[:tls_certificate_path] = @tls_certificate_path || ""
         s[:tls_certificate_password] = @tls_certificate_password || ""
         @rabbitmq_settings = s

--- a/logstash-mixin-rabbitmq_connection.gemspec
+++ b/logstash-mixin-rabbitmq_connection.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name            = 'logstash-mixin-rabbitmq_connection'
-  s.version         = '2.4.0'
+  s.version         = '2.4.1'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Common functionality for RabbitMQ plugins"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
as was brought to my attention today, it seems my last pull request broke the default behaviour when specifying ssl => true, as we now pass a string and march-hare does not validate what you pass to it and just assumes its the name of a valid securiry context, i'm truly sorry for the trouble this might have caused already but as i didnt use a boolean value in the config myself and the tests where green i assumed the change will be ok, this pull request fixes it

---

Error Message:
{:timestamp=>"2016-05-03T07:42:21.273000+0000", :message=>"true SSLContext not available", :class=>"Java::JavaSecurity::NoSuchAlgorithmException", :location=>"sun.security.jca.GetInstance.getInstance(sun/security/jca/GetInstance.java:159)", :level=>:warn, :file=>"logstash/inputs/rabbitmq.rb", :line=>"180", :method=>"register"}
