### PR TITLE
Remove LS Plugin API requirement

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,5 @@
+* 4.1.1
+  - Remove internal Logstash deps that were not necessary
 * 4.1.0
   - Fix SSL option to be boolean once again
   - Add separate ssl_version parameter

--- a/logstash-mixin-rabbitmq_connection.gemspec
+++ b/logstash-mixin-rabbitmq_connection.gemspec
@@ -1,7 +1,7 @@
 
 Gem::Specification.new do |s|
   s.name            = 'logstash-mixin-rabbitmq_connection'
-  s.version         = '4.1.0'
+  s.version         = '4.1.1'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Common functionality for RabbitMQ plugins"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"
@@ -15,9 +15,6 @@ Gem::Specification.new do |s|
 
   # Tests
   s.test_files = s.files.grep(%r{^(test|spec|features)/})
-
-  # Gem dependencies
-  s.add_runtime_dependency "logstash-core-plugin-api", "~> 2.0"
 
   s.platform = RUBY_PLATFORM
   s.add_runtime_dependency 'march_hare', ['~> 2.15.0'] #(MIT license)


### PR DESCRIPTION
This plugin doesn't actually use the Event API and this makes dep management easier
