### PR TITLE
Retry on java.io.IOException.

### DIFF
--- a/lib/logstash/plugin_mixins/rabbitmq_connection.rb
+++ b/lib/logstash/plugin_mixins/rabbitmq_connection.rb
@@ -130,14 +130,28 @@ module LogStash
       def connect!
         @hare_info = connect() unless @hare_info # Don't duplicate the conn!
       rescue MarchHare::Exception, java.io.IOException => e
+        error_message = if e.message.empty? && e.is_a?(java.io.IOException)
+          # IOException with an empty message is probably an instance of
+          # these problems:
+          # https://github.com/logstash-plugins/logstash-output-rabbitmq/issues/52
+          # https://github.com/rabbitmq/rabbitmq-java-client/issues/100
+          #
+          # Best guess is to help the user understand that there is probably
+          # some kind of configuration problem causing the error, but we
+          # can't really offer any more detailed hints :\
+          "An unknown error occurred. RabbitMQ gave us no hints as to the cause. Maybe this is a configuration error (invalid vhost, for example)?"
+        else
+          e.message
+        end
+
         if @logger.debug?
           @logger.error("RabbitMQ connection error, will retry.",
-                        :error_message => e.message,
+                        :error_message => error_message,
                         :exception => e.class.name,
                         :backtrace => e.backtrace)
         else
           @logger.error("RabbitMQ connection error, will retry.",
-                        :error_message => e.message,
+                        :error_message => error_message,
                         :exception => e.class.name)
         end
 

--- a/lib/logstash/plugin_mixins/rabbitmq_connection.rb
+++ b/lib/logstash/plugin_mixins/rabbitmq_connection.rb
@@ -130,10 +130,16 @@ module LogStash
       def connect!
         @hare_info = connect() unless @hare_info # Don't duplicate the conn!
       rescue MarchHare::Exception, java.io.IOException => e
-        @logger.error("RabbitMQ connection error, will retry.",
-                      :message => e.message,
-                      :exception => e.class.name,
-                      :backtrace => e.backtrace)
+        if @logger.debug?
+          @logger.error("RabbitMQ connection error, will retry.",
+                        :error_message => e.message,
+                        :exception => e.class.name,
+                        :backtrace => e.backtrace)
+        else
+          @logger.error("RabbitMQ connection error, will retry.",
+                        :error_message => e.message,
+                        :exception => e.class.name)
+        end
 
         sleep_for_retry
         retry

--- a/lib/logstash/plugin_mixins/rabbitmq_connection.rb
+++ b/lib/logstash/plugin_mixins/rabbitmq_connection.rb
@@ -129,7 +129,7 @@ module LogStash
 
       def connect!
         @hare_info = connect() unless @hare_info # Don't duplicate the conn!
-      rescue MarchHare::Exception => e
+      rescue MarchHare::Exception, java.io.IOException => e
         @logger.error("RabbitMQ connection error, will retry.",
                       :message => e.message,
                       :exception => e.class.name,

--- a/lib/logstash/plugin_mixins/rabbitmq_connection.rb
+++ b/lib/logstash/plugin_mixins/rabbitmq_connection.rb
@@ -139,7 +139,7 @@ module LogStash
           # Best guess is to help the user understand that there is probably
           # some kind of configuration problem causing the error, but we
           # can't really offer any more detailed hints :\
-          "An unknown error occurred. RabbitMQ gave us no hints as to the cause. Maybe this is a configuration error (invalid vhost, for example)?"
+          "An unknown error occurred. RabbitMQ gave no hints as to the cause. Maybe this is a configuration error (invalid vhost, for example). I recommend checking the RabbitMQ server logs for clues about this failure."
         else
           e.message
         end


### PR DESCRIPTION
In some [circumstances](https://github.com/rabbitmq/rabbitmq-java-client/issues/100), march-hare will throw a java.io.IOException
during connection setup. If this occurs, we should retry the connection
attempt.

This should solve https://github.com/logstash-plugins/logstash-output-rabbitmq/issues/52
