### PR TITLE
Add support for multiple hosts

### DIFF
--- a/lib/logstash/plugin_mixins/rabbitmq_connection.rb
+++ b/lib/logstash/plugin_mixins/rabbitmq_connection.rb
@@ -19,7 +19,9 @@ module LogStash
 
       def setup_rabbitmq_connection_config
         # RabbitMQ server address
-        config :host, :validate => :string, :required => true
+        config :host, :validate => :string, :default => ""
+
+        config :hosts, :validate => :array, :default => {}
 
         # RabbitMQ port to connect on
         config :port, :validate => :number, :default => 5672
@@ -100,6 +102,7 @@ module LogStash
         s = {
           :vhost => @vhost,
           :host  => @host,
+          :hosts => @hosts,
           :port  => @port,
           :user  => @user,
           :automatic_recovery => @automatic_recovery,
@@ -121,6 +124,10 @@ module LogStash
 
           s[:tls_certificate_path] = cert_path
           s[:tls_certificate_password] = cert_pass
+        end
+
+        if @host.to_s.empty? and @hosts.empty?
+          raise LogStash::ConfigurationError, "RabbitMQ Hosts need to be specified in either the host option or the hosts option"
         end
 
 

--- a/lib/logstash/plugin_mixins/rabbitmq_connection.rb
+++ b/lib/logstash/plugin_mixins/rabbitmq_connection.rb
@@ -18,10 +18,17 @@ module LogStash
       end
 
       def setup_rabbitmq_connection_config
-        # RabbitMQ server address
-        config :host, :validate => :string, :default => ""
-
-        config :hosts, :validate => :array, :default => {}
+        # RabbitMQ server address(es) 
+        # host can either be a single host, or a list of hosts
+        # i.e.
+        #   host => "localhost"
+        # or
+        #   host => ["host01", "host02]
+        #
+        # if multiple hosts are provided on the initial connection and any subsequent
+        # recovery attempts of the hosts is chosen at random and connected to.
+        # Note that only one host connection is active at a time.
+        config :host, :validate => :string, :required => true , :list => true
 
         # RabbitMQ port to connect on
         config :port, :validate => :number, :default => 5672
@@ -101,8 +108,7 @@ module LogStash
 
         s = {
           :vhost => @vhost,
-          :host  => @host,
-          :hosts => @hosts,
+          :hosts => @host,
           :port  => @port,
           :user  => @user,
           :automatic_recovery => @automatic_recovery,
@@ -125,11 +131,6 @@ module LogStash
           s[:tls_certificate_path] = cert_path
           s[:tls_certificate_password] = cert_pass
         end
-
-        if @host.to_s.empty? and @hosts.empty?
-          raise LogStash::ConfigurationError, "RabbitMQ Hosts need to be specified in either the host option or the hosts option"
-        end
-
 
         @rabbitmq_settings = s
       end

--- a/spec/plugin_mixins/rabbitmq_connection_spec.rb
+++ b/spec/plugin_mixins/rabbitmq_connection_spec.rb
@@ -58,6 +58,32 @@ describe LogStash::PluginMixins::RabbitMQConnection do
     it "should set tls_certificate_password to the expected value" do
       expect(instance.rabbitmq_settings[:tls_certificate_password]).to eql(rabbitmq_settings["ssl_certificate_password"])
     end
+
+    it "should set hosts to the expected value " do
+      expect(instance.rabbitmq_settings[:hosts][0]).to eql(host)
+    end
+
+    it "should only insert a single host entry" do
+      expect(instance.rabbitmq_settings[:hosts].length).to eql(1)
+    end
+  end
+
+  describe "rabbitmq_settings multiple hosts" do
+    let(:file) { Stud::Temporary.file }
+    let(:path) { file.path }
+    after { File.unlink(path)}
+
+    let(:rabbitmq_settings) { super.merge({"host" => ["host01", "host02", "host03"]}) }
+
+    it "should set hosts to the expected value" do
+      expect(instance.rabbitmq_settings[:hosts][0]).to eql("host01")
+      expect(instance.rabbitmq_settings[:hosts][1]).to eql("host02")
+      expect(instance.rabbitmq_settings[:hosts][2]).to eql("host03")
+    end
+
+    it "should insert 3 host entries" do
+      expect(instance.rabbitmq_settings[:hosts].length).to eql(3)
+    end
   end
 
   context "when connected" do


### PR DESCRIPTION
Add support for multiple hosts, the underlying support for multiple hosts has been in MarchHare since version 2.6.

A list of RabbitMq hosts is specified in the hosts configuration parameter.  The initial connection and any recovery attempts then choose a host at random from this list.
