### PR TITLE
Bump march_hare version to 2.19.0 to fix reconnect issues

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,8 @@
+* 4.1.3
+- Bump march_hare version to 2.19.0 to fix reconnection failures with
+  proxies. See
+  https://github.com/logstash-plugins/logstash-input-rabbitmq/issues/76 for
+  more info
 * 4.1.2
   - Retry the connection attempt if there is an IO Exception.
 * 4.1.1

--- a/logstash-mixin-rabbitmq_connection.gemspec
+++ b/logstash-mixin-rabbitmq_connection.gemspec
@@ -1,7 +1,7 @@
 
 Gem::Specification.new do |s|
   s.name            = 'logstash-mixin-rabbitmq_connection'
-  s.version         = '4.1.2'
+  s.version         = '4.1.3'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Common functionality for RabbitMQ plugins"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.test_files = s.files.grep(%r{^(test|spec|features)/})
 
   s.platform = RUBY_PLATFORM
-  s.add_runtime_dependency 'march_hare', ['~> 2.15.0'] #(MIT license)
+  s.add_runtime_dependency 'march_hare', ['~> 2.19.0'] #(MIT license)
   s.add_runtime_dependency 'stud', '~> 0.0.22'
 
   s.add_development_dependency 'logstash-devutils'


### PR DESCRIPTION
This fixes https://github.com/logstash-plugins/logstash-input-rabbitmq/issues/76 where with ha_proxy switching rabbitmq backends would cause it to stall indefinitely.
