### PR TITLE
Add conn shutdown error log. Improve other error log messages

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+* 4.2.0
+- Include URL of server when logging errors
+- Add warning log when connection is severed
 * 4.1.3
 - Bump march_hare version to 2.19.0 to fix reconnection failures with
   proxies. See

--- a/logstash-mixin-rabbitmq_connection.gemspec
+++ b/logstash-mixin-rabbitmq_connection.gemspec
@@ -1,7 +1,7 @@
 
 Gem::Specification.new do |s|
   s.name            = 'logstash-mixin-rabbitmq_connection'
-  s.version         = '4.1.3'
+  s.version         = '4.2.0'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Common functionality for RabbitMQ plugins"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"

--- a/spec/plugin_mixins/rabbitmq_connection_spec.rb
+++ b/spec/plugin_mixins/rabbitmq_connection_spec.rb
@@ -96,6 +96,7 @@ describe LogStash::PluginMixins::RabbitMQConnection do
       allow(connection).to receive(:create_channel).and_return(channel)
       allow(connection).to receive(:on_blocked)
       allow(connection).to receive(:on_unblocked)
+      allow(connection).to receive(:on_shutdown)
 
       instance.register
     end


### PR DESCRIPTION
Previously, if a connection died it would recover, but there would be no indication of an error. This was a problem in https://github.com/logstash-plugins/logstash-input-rabbitmq/issues/76

Including the URL will help users debug things.
