### PR TITLE
Bump March Hare to 2.21.0

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,5 @@
+* 4.2.2
+- Bump march_hare version to 2.21.0
 * 4.2.1
 - Bump march_hare version to 2.20.0 to fix reconnection issues
 * 4.2.0

--- a/logstash-mixin-rabbitmq_connection.gemspec
+++ b/logstash-mixin-rabbitmq_connection.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.test_files = s.files.grep(%r{^(test|spec|features)/})
 
   s.platform = RUBY_PLATFORM
-  s.add_runtime_dependency 'march_hare', ['~> 2.20.0'] #(MIT license)
+  s.add_runtime_dependency 'march_hare', ['~> 2.21.0'] #(MIT license)
   s.add_runtime_dependency 'stud', '~> 0.0.22'
 
   s.add_development_dependency 'logstash-devutils'


### PR DESCRIPTION
Thanks for contributing to Logstash! If you haven't already signed our CLA, here's a handy link: https://www.elastic.co/contributor-agreement/

See [release notes](https://github.com/ruby-amqp/march_hare/blob/2.x-stable/ChangeLog.md#changes-between-2200-and-2210-november-24th-2016).