### PR TITLE
Shared connections

### DIFF
--- a/lib/logstash/plugin_mixins/rabbitmq_connection.rb
+++ b/lib/logstash/plugin_mixins/rabbitmq_connection.rb
@@ -106,7 +106,7 @@ module LogStash
       def close_connection
         @rabbitmq_connection_stopping = true
         @hare_info.channel.close if channel_open?
-        if !!@connection_pool_name
+        if !@connection_pool_name.nil?
             cache_key = {:host => @host,:port => @port,:vhost => @vhost,:user => @user,:pool => @connection_pool_name}.freeze
             @@connection_cache_mutex.synchronize {
               if @@connection_cache.has_key?(cache_key) and (@@connection_cache[cache_key].ref_counter -= 1) == 0
@@ -153,7 +153,7 @@ module LogStash
 
       def connect!
         if !@hare_info # Don't duplicate the conn!
-            if !!@connection_pool_name
+            if !@connection_pool_name.nil?
               cache_key = {:host => @host,:port => @port,:vhost => @vhost,:user => @user,:pool => @connection_pool_name}.freeze 
               @@connection_cache_mutex.synchronize {
                 if @@connection_cache.has_key?(cache_key)

--- a/spec/plugin_mixins/rabbitmq_connection_spec.rb
+++ b/spec/plugin_mixins/rabbitmq_connection_spec.rb
@@ -146,7 +146,7 @@ describe LogStash::PluginMixins::RabbitMQConnection do
         if i == 1
           raise(MarchHare::ConnectionRefused, "Error!")
         else
-          double("connection")
+          double("connection",:create_channel => channel)
         end
       end
 

--- a/spec/plugin_mixins/rabbitmq_connection_spec.rb
+++ b/spec/plugin_mixins/rabbitmq_connection_spec.rb
@@ -135,10 +135,13 @@ describe LogStash::PluginMixins::RabbitMQConnection do
   # handled by the automatic retry mechanism built-in to MarchHare
   describe "initial connection exceptions" do
     subject { instance }
+    
+    let(:connection) { double("MarchHare Connection") }
+    let(:channel) { double("Channel") }
 
     before do
       allow(subject).to receive(:sleep_for_retry)
-
+      allow(connection).to receive(:create_channel).and_return(channel)
 
       i = 0
       allow(subject).to receive(:connect) do
@@ -146,7 +149,7 @@ describe LogStash::PluginMixins::RabbitMQConnection do
         if i == 1
           raise(MarchHare::ConnectionRefused, "Error!")
         else
-          double("connection",:create_channel => channel)
+          connection
         end
       end
 


### PR DESCRIPTION
To reduce the thread and connection number by sharing AMQP connections between the input/output RabbitMQ instances => [see here](https://github.com/logstash-plugins/logstash-input-rabbitmq/issues/93)