### PR TITLE
Fix a crash when `log.format: json` in Logstash.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,5 @@
+* 4.3.1
+- Fix a bug when `log.format: json` used in Logstash. When the socket shutdown handler was called, it would crash when trying to log the exception.
 * 4.3.0
 - Bump march hare to 3.0.0
 * 4.2.2

--- a/lib/logstash/plugin_mixins/rabbitmq_connection.rb
+++ b/lib/logstash/plugin_mixins/rabbitmq_connection.rb
@@ -205,7 +205,7 @@ module LogStash
            @logger.warn("RabbitMQ connection was closed!",
                           :url => connection_url(conn),
                           :automatic_recovery => @automatic_recovery,
-                          :cause => cause)
+                          :cause => cause.message)
         end
         connection.on_blocked do
           @logger.warn("RabbitMQ connection blocked! Check your RabbitMQ instance!",

--- a/logstash-mixin-rabbitmq_connection.gemspec
+++ b/logstash-mixin-rabbitmq_connection.gemspec
@@ -1,7 +1,7 @@
 
 Gem::Specification.new do |s|
   s.name            = 'logstash-mixin-rabbitmq_connection'
-  s.version         = '4.3.0'
+  s.version         = '4.3.1'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Common functionality for RabbitMQ plugins"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
The problem was that when `on_shutdown` is invoked, we were logging (on
purpose) the fact that a connection was shutdown. The exception object
was passed to the logger. The exception included a reference to the
socket (com.rabbitmq.client.impl.SocketFrameHandler) that was previously
open to RabbitMQ. When serializing this exception to JSON, Jackson is
calling `getTimeout`  on this object, which throws a SocketException
because the socket is closed.

The result was that our logger call was itself throwing an exception
because Jackson/JSON called a method that threw an exception. Oops!

For posterity, this is what the message logged like:

    2017-05-04 13:03:05,191 AMQP Connection 127.0.0.1:5672 ERROR java.net.SocketException: Socket is closed java.net.SocketException: Socket is closed

This error was reported to occur when Logstash was shutting down (thus
telling the rabbitmq output to terminate). Because it occurred during
shutdown, I do not believe this caused any measurable data flow
problems. It did cause alarm for users, though.

Originally filed at: https://github.com/elastic/logstash/issues/6906
