### PR TITLE
update travis build to current standards

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,11 +2,6 @@
 sudo: false
 language: ruby
 cache: bundler
-rvm:
-- jruby-1.7.25
-script:
-- bundle exec rspec spec
-jdk: oraclejdk8
 matrix:
   include:
   - rvm: jruby-9.1.13.0
@@ -18,3 +13,6 @@ matrix:
   - rvm: jruby-1.7.27
     env: LOGSTASH_BRANCH=5.6
   fast_finish: true
+install: true
+script: ci/build.sh
+jdk: oraclejdk8

--- a/Gemfile
+++ b/Gemfile
@@ -2,3 +2,11 @@ source 'https://rubygems.org'
 
 # Specify your gem's dependencies in logstash-mass_effect.gemspec
 gemspec
+
+logstash_path = ENV["LOGSTASH_PATH"] || "../../logstash"
+use_logstash_source = ENV["LOGSTASH_SOURCE"] && ENV["LOGSTASH_SOURCE"].to_s == "1"
+
+if Dir.exist?(logstash_path) && use_logstash_source
+  gem 'logstash-core', :path => "#{logstash_path}/logstash-core"
+  gem 'logstash-core-plugin-api', :path => "#{logstash_path}/logstash-core-plugin-api"
+end

--- a/ci/build.sh
+++ b/ci/build.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+# version: 1
+########################################################
+#
+# AUTOMATICALLY GENERATED! DO NOT EDIT
+#
+########################################################
+set -e
+
+echo "Starting build process in: `pwd`"
+source ./ci/setup.sh
+
+if [[ -f "ci/run.sh" ]]; then
+    echo "Running custom build script in: `pwd`/ci/run.sh"
+    source ./ci/run.sh
+else
+    echo "Running default build scripts in: `pwd`/ci/build.sh"
+    bundle install
+    bundle exec rake vendor
+    bundle exec rspec spec
+fi

--- a/ci/setup.sh
+++ b/ci/setup.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+# version: 1
+########################################################
+#
+# AUTOMATICALLY GENERATED! DO NOT EDIT
+#
+########################################################
+set -e
+if [ "$LOGSTASH_BRANCH" ]; then
+    echo "Building plugin using Logstash source"
+    BASE_DIR=`pwd`
+    echo "Checking out branch: $LOGSTASH_BRANCH"
+    git clone -b $LOGSTASH_BRANCH https://github.com/elastic/logstash.git ../../logstash --depth 1
+    printf "Checked out Logstash revision: %s\n" "$(git -C ../../logstash rev-parse HEAD)"
+    cd ../../logstash
+    echo "Building plugins with Logstash version:"
+    cat versions.yml
+    echo "---"
+    # We need to build the jars for that specific version
+    echo "Running gradle assemble in: `pwd`"
+    ./gradlew assemble
+    cd $BASE_DIR
+    export LOGSTASH_SOURCE=1
+else
+    echo "Building plugin using released gems on rubygems"
+fi


### PR DESCRIPTION
...and attempt to fix :
```
Gem::LoadError: You have already activated jar-dependencies 0.3.10, but your Gemfile requires jar-dependencies 0.3.11. Since jar-dependencies is a default gem, you can either remove your dependency on it or try updating to a newer version of bundler that supports jar-dependencies as a default gem.
```