### PR TITLE
Bug Fix: undefined method `value' for nil:NilClass with SSL enabled, but no certificates provided

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 5.0.2
+   - Bug Fix: undefined method `value' for nil:NilClass with SSL enabled, but no certificates provided [#109](https://github.com/logstash-plugins/logstash-input-rabbitmq/issues/109)
 ## 5.0.1
    - Relax constraint on march hare to allow 3.x [#44](https://github.com/logstash-plugins/logstash-mixin-rabbitmq_connection/issues/44)
    - Validate :ssl_certificate_password as a password [#43](https://github.com/logstash-plugins/logstash-mixin-rabbitmq_connection/issues/43)

--- a/lib/logstash/plugin_mixins/rabbitmq_connection.rb
+++ b/lib/logstash/plugin_mixins/rabbitmq_connection.rb
@@ -121,7 +121,7 @@ module LogStash
           s[:tls] = @ssl_version
 
           cert_path = @ssl_certificate_path
-          cert_pass = @ssl_certificate_password.value
+          cert_pass = @ssl_certificate_password.value if @ssl_certificate_password
 
           if !!cert_path ^ !!cert_pass
             raise LogStash::ConfigurationError, "RabbitMQ requires both ssl_certificate_path AND ssl_certificate_password to be set!"

--- a/logstash-mixin-rabbitmq_connection.gemspec
+++ b/logstash-mixin-rabbitmq_connection.gemspec
@@ -1,7 +1,7 @@
 
 Gem::Specification.new do |s|
   s.name            = 'logstash-mixin-rabbitmq_connection'
-  s.version         = '5.0.1'
+  s.version         = '5.0.2'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Common functionality for RabbitMQ plugins"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"

--- a/spec/plugin_mixins/rabbitmq_connection_spec.rb
+++ b/spec/plugin_mixins/rabbitmq_connection_spec.rb
@@ -68,6 +68,17 @@ describe LogStash::PluginMixins::RabbitMQConnection do
     end
   end
 
+  describe "ssl enabled, but no verification" do
+    let(:rabbitmq_settings) { super.merge({"connection_timeout" => 123,
+                                           "heartbeat" => 456,
+                                           "ssl" => true}) }
+
+    it "should not have any certificates set" do
+      expect(instance.rabbitmq_settings[:tls_certificate_password]).to be nil
+      expect(instance.rabbitmq_settings[:tls_certificate_path]).to be nil
+    end
+
+  end
   describe "rabbitmq_settings multiple hosts" do
     let(:file) { Stud::Temporary.file }
     let(:path) { file.path }


### PR DESCRIPTION
Fixes https://github.com/logstash-plugins/logstash-input-rabbitmq/issues/109

Note - the accompanying test seems trivial, but would have caught this bug.
