### PR TITLE
Fix custom port assignment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 6.1.1
+   - Fixed issue with custom port assignment when multiple hosts are specified. [#54](https://github.com/logstash-plugins/logstash-mixin-rabbitmq_connection/pull/54)
+
 ## 6.1.0
    - Updated `march_hare` dependency to `4.x`, which enables consumers to reliably manage a connection blocked/unblocked state machine that survives connection recovery.
    - Removed support for Logstash 5.x since `march_hare` >= 3.x is not compatible.

--- a/lib/logstash/plugin_mixins/rabbitmq_connection.rb
+++ b/lib/logstash/plugin_mixins/rabbitmq_connection.rb
@@ -93,10 +93,10 @@ module LogStash
       def rabbitmq_settings
         return @rabbitmq_settings if @rabbitmq_settings
 
+
         s = {
           :vhost => @vhost,
-          :hosts => @host,
-          :port  => @port,
+          :addresses => addresses_from_hosts_and_port(@host, @port),
           :user  => @user,
           :automatic_recovery => @automatic_recovery,
           :pass => @password ? @password.value : "guest",
@@ -121,6 +121,11 @@ module LogStash
 
         @rabbitmq_settings = s
       end
+
+      def addresses_from_hosts_and_port(hosts, port)
+        hosts.map {|host| host.include?(':') ? host : "#{host}:#{port}"}
+      end
+
 
       def connect!
         @hare_info = connect() unless @hare_info # Don't duplicate the conn!

--- a/lib/logstash/plugin_mixins/rabbitmq_connection.rb
+++ b/lib/logstash/plugin_mixins/rabbitmq_connection.rb
@@ -93,7 +93,6 @@ module LogStash
       def rabbitmq_settings
         return @rabbitmq_settings if @rabbitmq_settings
 
-
         s = {
           :vhost => @vhost,
           :addresses => addresses_from_hosts_and_port(@host, @port),
@@ -123,9 +122,10 @@ module LogStash
       end
 
       def addresses_from_hosts_and_port(hosts, port)
+        # Expand host to include port, unless port is already present
+        # (Allowing hosts with port was a previously undocumented feature)
         hosts.map {|host| host.include?(':') ? host : "#{host}:#{port}"}
       end
-
 
       def connect!
         @hare_info = connect() unless @hare_info # Don't duplicate the conn!

--- a/logstash-mixin-rabbitmq_connection.gemspec
+++ b/logstash-mixin-rabbitmq_connection.gemspec
@@ -1,7 +1,7 @@
 
 Gem::Specification.new do |s|
   s.name            = 'logstash-mixin-rabbitmq_connection'
-  s.version         = '6.1.0'
+  s.version         = '6.1.1'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Common functionality for RabbitMQ plugins"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
Fixes the ability to use custom ports for rabbitmq: the underlying
march hare library disregards the value of the port parameter
if the :hosts option is set to provide multiple addresses. This
commit changes the setup to use the :addresses option, which
enables a port to be included.

Fixes #53
