### PR TITLE
Use the correct host setting when logging the connected message.

### DIFF
--- a/lib/logstash/plugin_mixins/rabbitmq_connection.rb
+++ b/lib/logstash/plugin_mixins/rabbitmq_connection.rb
@@ -203,7 +203,7 @@ module LogStash
         end
 
         channel = connection.create_channel
-        @logger.info("Connected to RabbitMQ at #{rabbitmq_settings[:host]}")
+        @logger.info("Connected to RabbitMQ at #{rabbitmq_settings[:hosts]}")
 
         HareInfo.new(connection, channel)
       end


### PR DESCRIPTION
The "connected" log message is not showing the host it was connected. This pull request use the correct setting name in the log message.