### PR TITLE
Update march_hare dependency to 4.x.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 6.1.0
+   - Update march_hare dependency to 4.x.
+     Although this is a major version bump on a dependency, it is because 4.x now requires jdk8 which was always a dependency on logstash.
+
 ## 6.0.0
    - Removed obsolete options `verify_ssl`, `debug`, `tls_certificate_path` and `tls_certificate_password`
 

--- a/logstash-mixin-rabbitmq_connection.gemspec
+++ b/logstash-mixin-rabbitmq_connection.gemspec
@@ -1,7 +1,7 @@
 
 Gem::Specification.new do |s|
   s.name            = 'logstash-mixin-rabbitmq_connection'
-  s.version         = '6.0.0'
+  s.version         = '6.1.0'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Common functionality for RabbitMQ plugins"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.test_files = s.files.grep(%r{^(test|spec|features)/})
 
   s.platform = RUBY_PLATFORM
-  s.add_runtime_dependency 'march_hare', ['~> 3.0'] #(MIT license)
+  s.add_runtime_dependency 'march_hare', ['~> 4'] #(MIT license)
   s.add_runtime_dependency 'stud', '~> 0.0.22'
 
   s.add_development_dependency 'logstash-devutils'


### PR DESCRIPTION
Although this is a major version bump on a dependency, it is because 4.x now requires jdk8 which was always a dependency on logstash.